### PR TITLE
Custom timeout for service clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ pip3 install nats-py==2.2.0
 The NATS ROS Connector includes an example which demonstrates bi-directional messaging between two clients `ClientA` and `ClientB`. Each client is meant run on separate machine with distinct ROS Cores. With a NATS Server that's accessible to both clients, it's possible to bridge the networking gap between the clients and enable bi-directional communication. The example can scale to as many number of clients and topics as the network bandwidth and the NATS Server can handle. The messaging and services layout in the example is follows:
 
 -   `ClientA` publishes a topic called `clientA_talker` of msg type `std_msgs/Header` and subscribers to a topic called `clientA_listener` of msg type `std_msgs/String`.
--   `ClientB` publishes a topic called `clientA_listener` of msg type `std_msgs/Header` and subscribers to a topic called `clientA_listener` of msg type `std_msgs/String`.
+-   `ClientB` publishes a topic called `clientA_listener` of msg type `std_msgs/String` and subscribers to a topic called `clientA_talker` of msg type `std_msgs/Header`.
 -   `ClientA` advertises a service called `trigger_clientA` of service type `std_srvs/Trigger` and creates a service proxy to `trigger_clientB` of service type `std_srvs/SetBool`.
 -   `ClientB` advertises a service called `trigger_clientB` of service type `std_msgs/SetBool` and creates a service proxy to `trigger_clientA` of service type `std_srvs/Trigger`.
 

--- a/scripts/nats_connector.py
+++ b/scripts/nats_connector.py
@@ -56,6 +56,8 @@ if __name__ == "__main__":
     subscribers = load_param("~subscribers", [])
     services = load_param("~services", [])
     services_proxies = load_param("~service_proxies", [])
+    srv_req_timeout = load_param("~srv_req_timeout", 1)
+    print("srv_req_timeout: {}".format(srv_req_timeout))
     # Create event loop
     event_loop = asyncio.get_event_loop()
     # NATS Client
@@ -88,6 +90,7 @@ if __name__ == "__main__":
         user_jwt_cb,
         user_credentials,
         nkeys_seed,
+        srv_req_timeout
     )
     # Start NATS Client
     event_loop.create_task(nats_client.run())

--- a/scripts/nats_connector.py
+++ b/scripts/nats_connector.py
@@ -57,7 +57,6 @@ if __name__ == "__main__":
     services = load_param("~services", [])
     services_proxies = load_param("~service_proxies", [])
     srv_req_timeout = load_param("~srv_req_timeout", 1)
-    print("srv_req_timeout: {}".format(srv_req_timeout))
     # Create event loop
     event_loop = asyncio.get_event_loop()
     # NATS Client

--- a/src/nats_ros_connector/nats_client.py
+++ b/src/nats_ros_connector/nats_client.py
@@ -39,6 +39,7 @@ class NATSClient:
         user_jwt_cb=None,
         user_credentials=None,
         nkeys_seed=None,
+        srv_req_timeout=None
     ):
         self.host = nats_host
         self.publishers = publishers
@@ -71,6 +72,7 @@ class NATSClient:
         self.user_jwt_cb = user_jwt_cb
         self.user_credentials = user_credentials
         self.nkeys_seed = nkeys_seed
+        self.srv_req_timeout = srv_req_timeout
 
     async def run(self):
         self.nc = await nats.connect(
@@ -101,7 +103,7 @@ class NATSClient:
             signature_cb=self.signature_cb,
             user_jwt_cb=self.user_jwt_cb,
             user_credentials=self.user_credentials,
-            nkeys_seed=self.nkeys_seed,
+            nkeys_seed=self.nkeys_seed
         )
         # Register Subscribers
         for topic_name in self.subscribers:
@@ -118,7 +120,7 @@ class NATSClient:
         # Register Service Proxies
         for service_dict in self.service_proxies:
             NATSServiceProxy(
-                self.nc, service_dict["name"], service_dict["type"], self.event_loop
+                self.nc, service_dict["name"], service_dict["type"], self.event_loop, self.srv_req_timeout
             )
 
     async def close(self):


### PR DESCRIPTION
Slightly modified version allowing for a `srv_req_timeout` parameter to be passed in the launch file. I thought it is an improvement in those cases in which the server does some computation and needs something more than 1 second to provide the response. However, the default value for the parameter is still 1.

Another suggestion for future development could be to set the default value of `srv_req_timeout` to `None` (corresponding to infinite time)